### PR TITLE
feat: support set client transport

### DIFF
--- a/pkg/net/http/blademaster/client.go
+++ b/pkg/net/http/blademaster/client.go
@@ -74,7 +74,7 @@ func NewClient(c *ClientConfig) *Client {
 	}
 
 	originTransport := &xhttp.Transport{
-		DialContext:     client.dialContext,
+		DialContext:     client.DialContext,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 

--- a/pkg/net/http/blademaster/trace.go
+++ b/pkg/net/http/blademaster/trace.go
@@ -128,7 +128,7 @@ func (t *TraceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-func (client *Client) dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+func (client *Client) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	client.transport.connStart = time.Now()
 	defer func() {
 		client.transport.connEnd = time.Now()


### PR DESCRIPTION
调整 DialContext  访问权限，复用 client 提供的 context 连接到指定的网络地址，支持设置 client Transport 